### PR TITLE
Fix missing headers in delivery hook

### DIFF
--- a/crates/email/src/message/delivery_hooks.rs
+++ b/crates/email/src/message/delivery_hooks.rs
@@ -61,15 +61,8 @@ pub async fn try_delivery_hook(
     };
 
     let headers = parsed_message
-        .root_part()
-        .headers()
-        .iter()
-        .map(|h| {
-            (
-                h.name().to_string(),
-                h.value().as_text().unwrap_or_default().to_string(),
-            )
-        })
+        .headers_raw()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect();
 
     let principal = match server


### PR DESCRIPTION
I was taking headers from the first mime part, which meant some were empty.