### PR TITLE
Properly filter in queries when a single message is cached

### DIFF
--- a/crates/store/src/dispatch/search.rs
+++ b/crates/store/src/dispatch/search.rs
@@ -21,13 +21,10 @@ impl SearchStore {
     pub async fn query_account(&self, query: SearchQuery) -> trc::Result<Vec<u32>> {
         // Pre-filter by mask
         match query.mask.len().cmp(&1) {
-            Ordering::Equal => {
-                return Ok(vec![query.mask.min().unwrap()]);
-            }
             Ordering::Less => {
                 return Ok(vec![]);
             }
-            Ordering::Greater => {}
+            Ordering::Equal | Ordering::Greater => {}
         }
 
         // If the store does not support FTS, use the internal FTS store


### PR DESCRIPTION
Fixes issue described in https://github.com/stalwartlabs/stalwart/discussions/2654