### PR TITLE
Fix Email/query inMailboxOtherThan logic

### DIFF
--- a/crates/jmap/src/email/query.rs
+++ b/crates/jmap/src/email/query.rs
@@ -172,11 +172,11 @@ impl EmailQuery for Server {
                                 if item
                                     .mailboxes
                                     .iter()
-                                    .any(|mb| mailboxes.contains(&mb.mailbox_id))
+                                    .any(|mb| !mailboxes.contains(&mb.mailbox_id))
                                 {
-                                    None
-                                } else {
                                     Some(item.document_id)
+                                } else {
+                                    None
                                 }
                             }),
                         )));


### PR DESCRIPTION
Relevant spec (https://jmap.io/spec-mail.html#emailquery)

inMailboxOtherThan: Id[] A list of Mailbox ids. An Email must be in at least one Mailbox not in this list to match the condition. This is to allow messages solely in trash/spam to be easily excluded from a search.