### PR TITLE
Distributed tracing

### DIFF
--- a/crates/trc/src/event/description.rs
+++ b/crates/trc/src/event/description.rs
@@ -120,6 +120,8 @@ impl HttpEvent {
             HttpEvent::XForwardedMissing => "X-Forwarded-For header is missing",
             HttpEvent::ConnectionStart => "HTTP connection started",
             HttpEvent::ConnectionEnd => "HTTP connection ended",
+            HttpEvent::RequestStart => "HTTP request started",
+            HttpEvent::RequestEnd => "HTTP request ended",
         }
     }
 
@@ -132,6 +134,8 @@ impl HttpEvent {
             HttpEvent::XForwardedMissing => "The X-Forwarded-For header is missing",
             HttpEvent::ConnectionStart => "An HTTP connection was started",
             HttpEvent::ConnectionEnd => "An HTTP connection was ended",
+            HttpEvent::RequestStart => "An HTTP request was started",
+            HttpEvent::RequestEnd => "An HTTP request was ended",
         }
     }
 }

--- a/crates/trc/src/event/level.rs
+++ b/crates/trc/src/event/level.rs
@@ -354,7 +354,10 @@ impl EventType {
                 | SpamEvent::ModelNotFound => Level::Info,
             },
             EventType::Http(event) => match event {
-                HttpEvent::ConnectionStart | HttpEvent::ConnectionEnd => Level::Debug,
+                HttpEvent::ConnectionStart
+                | HttpEvent::ConnectionEnd
+                | HttpEvent::RequestStart
+                | HttpEvent::RequestEnd => Level::Debug,
                 HttpEvent::XForwardedMissing => Level::Warn,
                 HttpEvent::Error | HttpEvent::RequestUrl => Level::Debug,
                 HttpEvent::RequestBody | HttpEvent::ResponseBody => Level::Trace,

--- a/crates/trc/src/event/mod.rs
+++ b/crates/trc/src/event/mod.rs
@@ -250,6 +250,7 @@ impl EventType {
                 | EventType::ManageSieve(ManageSieveEvent::ConnectionStart)
                 | EventType::Pop3(Pop3Event::ConnectionStart)
                 | EventType::Http(HttpEvent::ConnectionStart)
+                | EventType::Http(HttpEvent::RequestStart)
                 | EventType::Delivery(DeliveryEvent::AttemptStart)
         )
     }
@@ -263,6 +264,7 @@ impl EventType {
                 | EventType::ManageSieve(ManageSieveEvent::ConnectionEnd)
                 | EventType::Pop3(Pop3Event::ConnectionEnd)
                 | EventType::Http(HttpEvent::ConnectionEnd)
+                | EventType::Http(HttpEvent::RequestEnd)
                 | EventType::Delivery(DeliveryEvent::AttemptEnd)
         )
     }

--- a/crates/trc/src/ipc/collector.rs
+++ b/crates/trc/src/ipc/collector.rs
@@ -72,6 +72,8 @@ const MANAGE_SIEVE_CONN_START: usize =
 const MANAGE_SIEVE_CONN_END: usize = EventType::ManageSieve(ManageSieveEvent::ConnectionEnd).id();
 const EV_ATTEMPT_START: usize = EventType::Delivery(DeliveryEvent::AttemptStart).id();
 const EV_ATTEMPT_END: usize = EventType::Delivery(DeliveryEvent::AttemptEnd).id();
+const HTTP_REQUEST_START: usize = EventType::Http(HttpEvent::RequestStart).id();
+const HTTP_REQUEST_END: usize = EventType::Http(HttpEvent::RequestEnd).id();
 
 const STALE_SPAN_CHECK_WATERMARK: usize = 8000;
 const SPAN_MAX_HOLD: u64 = 60 * 60 * 24; // 1 day
@@ -134,7 +136,8 @@ impl Collector {
                                 | POP3_CONN_START
                                 | SMTP_CONN_START
                                 | MANAGE_SIEVE_CONN_START
-                                | EV_ATTEMPT_START => {
+                                | EV_ATTEMPT_START
+                                | HTTP_REQUEST_START => {
                                     let event = Arc::new(event);
                                     self.active_spans.insert(
                                         event.span_id().unwrap_or_else(|| {
@@ -157,7 +160,8 @@ impl Collector {
                                 | POP3_CONN_END
                                 | SMTP_CONN_END
                                 | MANAGE_SIEVE_CONN_END
-                                | EV_ATTEMPT_END => {
+                                | EV_ATTEMPT_END
+                                | HTTP_REQUEST_END => {
                                     if let Some(span) = self
                                         .active_spans
                                         .remove(&event.span_id().expect("Missing span ID"))

--- a/crates/trc/src/lib.rs
+++ b/crates/trc/src/lib.rs
@@ -140,6 +140,9 @@ pub enum Key {
     Value,
     Version,
     QueueName,
+    TraceId,
+    TraceParentId,
+    TraceFlags,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -202,6 +205,8 @@ pub enum HttpEvent {
     RequestBody,
     ResponseBody,
     XForwardedMissing,
+    RequestStart,
+    RequestEnd,
 }
 
 #[event_type]

--- a/crates/trc/src/serializers/binary.rs
+++ b/crates/trc/src/serializers/binary.rs
@@ -903,6 +903,8 @@ impl EventType {
             EventType::Spam(SpamEvent::TrainStarted) => 588,
             EventType::Spam(SpamEvent::ModelLoaded) => 589,
             EventType::Store(StoreEvent::MeilisearchError) => 590,
+            EventType::Http(HttpEvent::RequestStart) => 591,
+            EventType::Http(HttpEvent::RequestEnd) => 592,
         }
     }
 
@@ -1544,6 +1546,8 @@ impl EventType {
             588 => Some(EventType::Spam(SpamEvent::TrainStarted)),
             589 => Some(EventType::Spam(SpamEvent::ModelLoaded)),
             590 => Some(EventType::Store(StoreEvent::MeilisearchError)),
+            591 => Some(EventType::Http(HttpEvent::RequestStart)),
+            592 => Some(EventType::Http(HttpEvent::RequestEnd)),
             _ => None,
         }
     }
@@ -1618,6 +1622,9 @@ impl Key {
             Key::Value => 63,
             Key::Version => 64,
             Key::QueueName => 65,
+            Key::TraceId => 66,
+            Key::TraceParentId => 67,
+            Key::TraceFlags => 68,
         }
     }
 
@@ -1689,6 +1696,9 @@ impl Key {
             63 => Some(Key::Value),
             64 => Some(Key::Version),
             65 => Some(Key::QueueName),
+            66 => Some(Key::TraceId),
+            67 => Some(Key::TraceParentId),
+            68 => Some(Key::TraceFlags),
             _ => None,
         }
     }


### PR DESCRIPTION
Currently, stalwart doesn't _really_ have tracing (it emits events for a couple use cases, but doesn't emit spans and doesn't support context propagation)