### PR TITLE
Honor $Junk/$NotJunk keywords over spam classifier verdict

### DIFF
--- a/crates/email/src/message/ingest.rs
+++ b/crates/email/src/message/ingest.rs
@@ -319,6 +319,15 @@ impl EmailIngest for Server {
                         }
                     }
 
+                    // Honor $Junk/$NotJunk flags set by delivery hooks or sieve
+                    if is_spam && params.keywords.contains(&Keyword::NotJunk) {
+                        is_spam = false;
+                        overridden = Some("notjunk-keyword");
+                    } else if !is_spam && params.keywords.contains(&Keyword::Junk) {
+                        is_spam = true;
+                        overridden = Some("junk-keyword");
+                    }
+
                     // Add Spam-Status header
                     const HEADER: &str = "X-Spam-Status";
                     let offset_field = extra_headers.len();


### PR DESCRIPTION
## Summary
- Delivery hooks and sieve scripts can set `$Junk` or `$NotJunk` keyword flags, but `email_ingest` previously ignored them and relied solely on the spam classifier verdict
- Now `$NotJunk` prevents a spam-classified message from being routed to Junk, and `$Junk` forces a ham-classified message into Junk
- The `X-Spam-Status` header reflects the override reason

## Test plan
- [ ] `cargo build` and `cargo test` pass
- [ ] Delivery hook returning `$NotJunk` on a spam-classified message keeps it in Inbox
- [ ] Delivery hook returning `$Junk` on a ham-classified message routes it to Junk
- [ ] `X-Spam-Status` header shows override reason (`notjunk-keyword` / `junk-keyword`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)