### PR TITLE
Pin rust to version 1.92

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Stalwart Dockerfile
 # Credits: https://github.com/33KK 
 
-FROM --platform=$BUILDPLATFORM docker.io/lukemathwalker/cargo-chef:latest-rust-slim-trixie AS chef
+FROM --platform=$BUILDPLATFORM docker.io/lukemathwalker/cargo-chef:latest-rust-1.92.0-slim-trixie AS chef
 WORKDIR /build
 
 FROM --platform=$BUILDPLATFORM chef AS planner


### PR DESCRIPTION
Our last build failed due to a transitive dependency (`rkyv` via `sieve-rs`). Pinning rust to a probably good version (build logs have expired) to attempt to fix.

It looks like https://github.com/stalwartlabs/sieve/issues/14 fixes the issue, but I want to wait until we upgrade to pull it in from upstream. Pinning rust version here is a good idea regardless.