### PR TITLE
Gracefully handle delivery hook JSON parse errors

### DIFF
--- a/crates/email/src/hooks/client.rs
+++ b/crates/email/src/hooks/client.rs
@@ -7,7 +7,7 @@
 use utils::HttpLimitResponse;
 use common::config::smtp::delivery_hooks::DeliveryHook;
 
-use super::{Request, Response};
+use super::{Action, Request, Response};
 
 pub async fn send_delivery_hook_request(hook: &DeliveryHook, request: Request) -> Result<Response, String> {
     let response = reqwest::Client::builder()
@@ -26,15 +26,28 @@ pub async fn send_delivery_hook_request(hook: &DeliveryHook, request: Request) -
         .map_err(|err| format!("Delivery hook request failed: {err}"))?;
 
     if response.status().is_success() {
-        serde_json::from_slice(
-            response
-                .bytes_with_limit(hook.max_response_size)
-                .await
-                .map_err(|err| format!("Failed to parse delivery hook response: {}", err))?
-                .ok_or_else(|| "Delivery hook response too large".to_string())?
-                .as_ref(),
-        )
-        .map_err(|err| format!("Failed to parse delivery hook response: {}", err))
+        let bytes = response
+            .bytes_with_limit(hook.max_response_size)
+            .await
+            .map_err(|err| format!("Failed to parse delivery hook response: {}", err))?
+            .ok_or_else(|| "Delivery hook response too large".to_string())?;
+        let trimmed = bytes.as_ref().trim_ascii();
+        match serde_json::from_slice(trimmed) {
+            Ok(parsed) => Ok(parsed),
+            Err(err) => {
+                trc::event!(
+                    Delivery(trc::DeliveryEvent::RawOutput),
+                    Reason = format!("Failed to parse delivery hook response: {err}"),
+                    Contents = String::from_utf8_lossy(trimmed).into_owned(),
+                );
+                Ok(Response {
+                    action: Action::Accept,
+                    modifications: Vec::new(),
+                    skip_inbox: false,
+                    flags: Vec::new(),
+                })
+            }
+        }
     } else {
         Err(format!(
             "Delivery hook request failed with code {}: {}",


### PR DESCRIPTION
## Summary
- **Trim whitespace** from delivery hook response bytes before JSON parsing, fixing "trailing characters" errors caused by trailing newlines (common with Go HTTP handlers)
- **Fall back to Accept** on JSON parse failure instead of returning an error — prevents `tempfail_on_error` from blocking email delivery due to malformed hook responses
- Log the parse error and raw response body via `trc::event!` for debugging

## Test plan
- [ ] `cargo check -p email` passes (verified locally)
- [ ] Deploy and confirm delivery hooks with trailing newlines no longer block delivery
- [ ] Verify that HTTP-level errors (timeouts, non-2xx status) still propagate as errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)