### PR TITLE
Allow delivery hooks to set custom email preview text

### DIFF
--- a/crates/email/src/hooks/client.rs
+++ b/crates/email/src/hooks/client.rs
@@ -45,6 +45,7 @@ pub async fn send_delivery_hook_request(hook: &DeliveryHook, request: Request) -
                     modifications: Vec::new(),
                     skip_inbox: false,
                     flags: Vec::new(),
+                    preview_text: None,
                 })
             }
         }

--- a/crates/email/src/hooks/mod.rs
+++ b/crates/email/src/hooks/mod.rs
@@ -50,6 +50,8 @@ pub struct Response {
     pub skip_inbox: bool,
     #[serde(default)]
     pub flags: Vec<String>,
+    #[serde(default)]
+    pub preview_text: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/crates/email/src/message/delivery.rs
+++ b/crates/email/src/message/delivery.rs
@@ -858,10 +858,11 @@ async fn deliver_to_recipient(
         let mut owned_new_raw: Option<Vec<u8>> = None;
         let mut use_modified = false;
         let mut parsed_for_ingest = parsed_output_message.clone();
+        let mut hook_preview_text: Option<String> = None;
         match try_delivery_hook(server, uid, &sender, &rcpt.address, &parsed_output_message).await
         {
             Ok(result) => {
-                let (hook_mailboxes, hook_flags, skip_inbox, hook_modifications) = match result {
+                let (hook_mailboxes, hook_flags, skip_inbox, hook_modifications, preview_text) = match result {
                     Some(v) => v,
                     None => {
                         // Discard without error
@@ -923,6 +924,8 @@ async fn deliver_to_recipient(
                         }
                     }
                 }
+
+                hook_preview_text = preview_text;
 
                 // Separate modifications by type
                 let mut add_headers: Vec<(String, String)> = Vec::new();
@@ -1012,6 +1015,7 @@ async fn deliver_to_recipient(
                     is_spam: rcpt.is_spam,
                 },
                 session_id,
+                preview_text: hook_preview_text,
             })
             .await
         {

--- a/crates/email/src/message/delivery_hooks.rs
+++ b/crates/email/src/message/delivery_hooks.rs
@@ -49,8 +49,9 @@ pub async fn try_delivery_hook(
     sender: &str,
     recipient: &str,
     parsed_message: &mail_parser::Message<'_>,
-) -> trc::Result<Option<(HashSet<u32>, HashSet<String>, bool, Vec<ModificationOut>)>> {
-    let default_response = Some((HashSet::new(), HashSet::new(), false, Vec::new()));
+) -> trc::Result<Option<(HashSet<u32>, HashSet<String>, bool, Vec<ModificationOut>, Option<String>)>>
+{
+    let default_response = Some((HashSet::new(), HashSet::new(), false, Vec::new(), None));
 
     let envelope = hooks::Envelope {
         from: hooks::Address {
@@ -140,6 +141,7 @@ pub async fn try_delivery_hook(
     let mut flags = HashSet::new();
     let mut skip_inbox = false;
     let mut modifications_out: Vec<ModificationOut> = Vec::new();
+    let mut preview_text: Option<String> = None;
     let mut should_tempfail = false;
     let mut should_permfail = false;
 
@@ -154,6 +156,10 @@ pub async fn try_delivery_hook(
             Ok(response) => {
                 if response.skip_inbox {
                     skip_inbox = true;
+                }
+
+                if preview_text.is_none() {
+                    preview_text = response.preview_text;
                 }
 
                 for flag in response.flags {
@@ -318,5 +324,5 @@ pub async fn try_delivery_hook(
         );
     }
 
-    Ok(Some((mailbox_ids, flags, skip_inbox, modifications_out)))
+    Ok(Some((mailbox_ids, flags, skip_inbox, modifications_out, preview_text)))
 }

--- a/crates/email/src/message/index/metadata.rs
+++ b/crates/email/src/message/index/metadata.rs
@@ -12,6 +12,8 @@ use crate::message::{
         MessageMetadataPart, build_metadata_contents,
     },
 };
+use std::borrow::Cow;
+
 use common::storage::index::ObjectIndexBuilder;
 use mail_parser::{
     PartType,
@@ -123,15 +125,20 @@ impl IndexMessage for BatchBuilder {
         blob_hash: BlobHash,
         data: MessageData,
         received_at: u64,
+        preview_override: Option<String>,
     ) -> trc::Result<&mut Self> {
         let mut has_attachments = false;
-        let mut preview = None;
-        let preview_part_id = message
-            .text_body
-            .first()
-            .or_else(|| message.html_body.first())
-            .copied()
-            .unwrap_or(u32::MAX);
+        let mut preview = preview_override.map(|t| Cow::Owned(t.replace('\r', "")));
+        let preview_part_id = if preview.is_none() {
+            message
+                .text_body
+                .first()
+                .or_else(|| message.html_body.first())
+                .copied()
+                .unwrap_or(u32::MAX)
+        } else {
+            u32::MAX
+        };
 
         for (part_id, part) in message.parts.iter().take(MAX_MESSAGE_PARTS).enumerate() {
             let part_id = part_id as u32;

--- a/crates/email/src/message/index/mod.rs
+++ b/crates/email/src/message/index/mod.rs
@@ -107,5 +107,6 @@ pub(super) trait IndexMessage {
         blob_hash: BlobHash,
         data: MessageData,
         received_at: u64,
+        preview_override: Option<String>,
     ) -> trc::Result<&mut Self>;
 }

--- a/crates/email/src/message/ingest.rs
+++ b/crates/email/src/message/ingest.rs
@@ -66,6 +66,7 @@ pub struct IngestEmail<'x> {
     pub received_at: Option<u64>,
     pub source: IngestSource<'x>,
     pub session_id: u64,
+    pub preview_text: Option<String>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -625,6 +626,7 @@ impl EmailIngest for Server {
                 blob_hash.clone(),
                 data,
                 params.received_at.unwrap_or_else(now),
+                params.preview_text,
             )
             .caused_by(trc::location!())?
             .set(

--- a/crates/http/src/management/enterprise/undelete.rs
+++ b/crates/http/src/management/enterprise/undelete.rs
@@ -281,6 +281,7 @@ impl UndeleteApi for Server {
                                             received_at: request.time.into(),
                                             source: IngestSource::Restore,
                                             session_id: session.session_id,
+                                            preview_text: None,
                                         })
                                         .await
                                     {

--- a/crates/imap/src/op/append.rs
+++ b/crates/imap/src/op/append.rs
@@ -114,6 +114,7 @@ impl<T: SessionStream> SessionData<T> {
                         train_classifier: true,
                     },
                     session_id: self.session_id,
+                    preview_text: None,
                 })
                 .await
             {

--- a/crates/jmap/src/email/import.rs
+++ b/crates/jmap/src/email/import.rs
@@ -161,6 +161,7 @@ impl EmailImport for Server {
                     keywords: email.keywords,
                     received_at: email.received_at.map(|r| r.into()),
                     session_id: session.session_id,
+                    preview_text: None,
                 })
                 .await
             {

--- a/crates/jmap/src/email/set.rs
+++ b/crates/jmap/src/email/set.rs
@@ -766,6 +766,7 @@ impl EmailSet for Server {
                         train_classifier: true,
                     },
                     session_id: session.session_id,
+                    preview_text: None,
                 })
                 .await
             {

--- a/tests/src/jmap/mail/thread_merge.rs
+++ b/tests/src/jmap/mail/thread_merge.rs
@@ -241,6 +241,7 @@ async fn test_multi_thread(params: &mut JMAPTest) {
                             is_spam: false,
                         },
                         session_id: 0,
+                        preview_text: None,
                     })
                     .await
                 {


### PR DESCRIPTION
## Summary
- Adds an optional `preview_text` field to the delivery hook JSON response
- When provided, the hook preview text is used directly instead of auto-extracting from the email body (skipping HTML-to-text conversion and body scanning)
- First non-None `preview_text` wins when multiple hooks run in parallel
- Plumbed through `try_delivery_hook` -> `IngestEmail` -> `index_message` -> `MessageMetadata`

## Test plan
- [ ] Verify delivery hook without `preview_text` field behaves identically to before (backward compatible via `#[serde(default)]`)
- [ ] Verify delivery hook with `"preview_text": "custom text"` stores the custom preview
- [ ] Verify carriage return characters are stripped from the override preview
- [ ] Verify non-SMTP ingestion paths (JMAP, IMAP, restore) are unaffected (`preview_text: None`)
- [ ] `cargo build` passes
- [ ] `cargo test --lib` passes

Generated with [Claude Code](https://claude.com/claude-code)