### PR TITLE
Fix invalid JMAP date serialization for malformed email headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4271,9 +4271,9 @@ dependencies = [
 
 [[package]]
 name = "mail-parser"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf4390741c4e6fa330bdeccdfb580815dbb462952de91838b723357985119a3"
+checksum = "f82a3d6522697593ba4c683e0a6ee5a40fee93bc1a525e3cc6eeb3da11fd8897"
 dependencies = [
  "encoding_rs",
  "hashify",

--- a/crates/jmap-proto/src/types/date.rs
+++ b/crates/jmap-proto/src/types/date.rs
@@ -178,6 +178,10 @@ impl UTCDate {
 
 impl Display for UTCDate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.is_valid() {
+            return write!(f, "1970-01-01T00:00:00Z");
+        }
+
         if self.tz_hour != 0 || self.tz_minute != 0 {
             write!(
                 f,
@@ -241,6 +245,33 @@ impl From<u64> for UTCDate {
 mod tests {
     use crate::types::date::UTCDate;
     use std::str::FromStr;
+
+    #[test]
+    fn invalid_dates_display_as_epoch() {
+        // Year > 4 digits (from https://github.com/stalwartlabs/mail-parser/pull/130)
+        let date = UTCDate {
+            year: 30579,
+            month: 12,
+            day: 6,
+            hour: 15,
+            minute: 30,
+            second: 8,
+            ..Default::default()
+        };
+        assert_eq!(date.to_string(), "1970-01-01T00:00:00Z");
+
+        // Invalid month (from https://github.com/stalwartlabs/mail-parser/pull/130)
+        let date = UTCDate {
+            year: 1911,
+            month: 219,
+            day: 3,
+            hour: 19,
+            minute: 46,
+            second: 0,
+            ..Default::default()
+        };
+        assert_eq!(date.to_string(), "1970-01-01T00:00:00Z");
+    }
 
     #[test]
     fn parse_jmap_date() {

--- a/crates/jmap/src/email/headers.rs
+++ b/crates/jmap/src/email/headers.rs
@@ -497,7 +497,7 @@ pub(crate) fn unwrap_date(value: Value<'_, EmailProperty, EmailValue>) -> Option
 }
 
 fn from_mail_datetime(date: DateTime) -> Value<'static, EmailProperty, EmailValue> {
-    Value::Element(EmailValue::Date(UTCDate {
+    let utc_date = UTCDate {
         year: date.year,
         month: date.month,
         day: date.day,
@@ -507,6 +507,11 @@ fn from_mail_datetime(date: DateTime) -> Value<'static, EmailProperty, EmailValu
         tz_before_gmt: date.tz_before_gmt,
         tz_hour: date.tz_hour,
         tz_minute: date.tz_minute,
+    };
+    Value::Element(EmailValue::Date(if utc_date.is_valid() {
+        utc_date
+    } else {
+        UTCDate::default()
     }))
 }
 


### PR DESCRIPTION
## Summary
- Update mail-parser 0.11.1 to 0.11.2, pulling in the fix from https://github.com/stalwartlabs/mail-parser/pull/130 to prevent new invalid dates
- Return epoch (`1970-01-01T00:00:00Z`) for invalid dates in `UTCDate` `Display` impl, fixing already-stored bad dates
- Validate dates at the mail-parser to `UTCDate` conversion point in `from_mail_datetime`

Fixes https://kagi.sentry.io/issues/7339914128/?project=4510160495640578 — Go clients fail to parse dates like `"30579-12-06T15:30:08Z"` produced by a mail-parser bug when parsing Received headers with RFC 822 long header tab syntax.

## Test plan
- [x] `cargo test -p jmap_proto -- types::date` passes (2 tests: existing + new invalid date tests)
- [ ] Verify Sentry issue stops recurring after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)