### PR TITLE
fix: build the image on Rust 1.96 (libsqlite3-sys needs cfg_select)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # FORK CHANGES:
 # trixie provides v19 of libclang-dev, not v16, https://packages.debian.org/trixie/libclang-dev
 # elastic is no longer a feature, and wasn't updated here https://github.com/stalwartlabs/stalwart/commit/472bddf733377018e9c8d0828358f91dc0602ffa#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL314
+# the sqlite feature pulls libsqlite3-sys 0.38.1, whose build script uses the
+# cfg_select! macro (stable as of Rust 1.95), so the cargo-chef base is pinned to
+# 1.96 rather than 1.92.
 
 # Stalwart Dockerfile
 # Credits: https://github.com/33KK
 
-FROM --platform=$BUILDPLATFORM docker.io/lukemathwalker/cargo-chef:latest-rust-1.92.0-slim-trixie AS chef
+FROM --platform=$BUILDPLATFORM docker.io/lukemathwalker/cargo-chef:latest-rust-1.96.0-slim-trixie AS chef
 WORKDIR /build
 
 FROM --platform=$BUILDPLATFORM chef AS planner


### PR DESCRIPTION
## Summary

The `stalwart` Cloud Build on `main` (`01e49e7`) fails in `cargo chef cook --features "sqlite ..."`:

```
error[E0658]: use of unstable library feature `cfg_select`
  --> libsqlite3-sys-0.38.1/build.rs:110
error: could not compile `libsqlite3-sys` (build script)
```

`libsqlite3-sys 0.38.1` (pulled by the `sqlite` feature via `rusqlite 0.40.1`) uses the `cfg_select!` macro in its build script, which is **stable only as of Rust 1.95.0**. The `cargo-chef` builder base was pinned to **1.92.0**.

This bumps the builder base to `cargo-chef:latest-rust-1.96.0-slim-trixie`. The fork's own crates compile fine on 1.92 (the postgres-only nix build proves it); only `libsqlite3-sys` needs the newer toolchain. No `Cargo.toml` / `Cargo.lock` change.

Verified `0.37.0` is the last `libsqlite3-sys` without `cfg_select`, but `rusqlite 0.40.1` requires `^0.38` — so bumping Rust (not pinning the crate down) is the correct fix.

Towards EMAIL-810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
