### PR TITLE
fix: require the configured OIDC username claim instead of falling back to email

### DIFF
--- a/crates/directory/src/backend/oidc/lookup.rs
+++ b/crates/directory/src/backend/oidc/lookup.rs
@@ -243,16 +243,20 @@ impl OpenIdDirectory {
             }
         }
 
-        if self.config.claim_email != "email"
-            && let Some(val) = claims.get("email").and_then(|v| v.as_str())
-            && val.contains('@')
-        {
-            return Ok(val.to_string());
-        }
-
-        Err(OidcError::AuthorizationFailed(
-            "Could not determine a valid email address for account".to_string(),
-        ))
+        // The configured claim is the only accepted source of identity. Resolving
+        // from the standard `email` claim instead would authenticate the caller as
+        // whatever address their IdP reports, which in a deployment that provisions
+        // mailboxes out of band names a different account — one `synchronize_account`
+        // will create if the domain happens to be local. Nothing in this path
+        // consults `email_verified`, so there is no check that would make that safe.
+        //
+        // Reported as `Provider` rather than `AuthorizationFailed` so `authenticate`
+        // maps it to `AuthEvent::Error`: a missing contracted claim is a
+        // misconfiguration worth logging, and `AuthEvent::Failed` resolves to DEBUG.
+        Err(OidcError::Provider(format!(
+            "Claim '{}' is missing or is not a valid email address",
+            self.config.claim_email
+        )))
     }
 }
 

--- a/tests/src/directory/oidc.rs
+++ b/tests/src/directory/oidc.rs
@@ -120,6 +120,23 @@ pub async fn test() {
         }
     );
 
+    // A configured claim the IdP does not issue must fail, rather than resolving the
+    // account from the standard `email` claim. The token here carries `email`, so a
+    // fallback would silently authenticate as john.doe@example.org.
+    let mut config_missing_claim = config.clone();
+    config_missing_claim.claim_username = "nonexistent_claim".to_string();
+    assert!(
+        OpenIdDirectory::open(config_missing_claim)
+            .await
+            .unwrap()
+            .authenticate(&Credentials::Bearer {
+                username: None,
+                token: token.clone(),
+            })
+            .await
+            .is_err()
+    );
+
     // Not matching the required audience should fail
     let mut config_wrong_audience = config.clone();
     config_wrong_audience.require_audience = Some("wrong_audience".to_string());


### PR DESCRIPTION
## Why

Our OIDC directory is configured with `claimUsername = "kagi_mail_email"`, a claim kagi-login appends to Zitadel's userinfo response. When that claim is missing, `resolve_email` falls back to the standard `email` claim — the user's **personal** address — and resolves a principal from it.

The fallback was gated only on `claim_email != "email"`, which is a guard against reading the same claim twice, not a policy. For any directory with a custom username claim it was effectively unconditional, and it triggered on three separate inputs: claim absent, claim present but not a JSON string, or a bare value with no `usernameDomain` configured.

This surfaced as background Kagi Mail jobs failing with `HTTP 401: You have to authenticate first.` (`EMAIL-BACKEND-11V`, `11N`, `11X`). Over one 48h window of prod logs there were 10 rejections across ≥6 users, each naming an irrelevant personal domain — `gmail.com`, `pm.me`, `posteo.com`, `tuta.io` — because that is what the fallback resolved. Three correlate to a Sentry job failure to the exact second.

## Why this is more than a confusing error message

Where the fallback domain *is* local, `synchronize_account` proceeds: `validate_address` checks only that the domain exists, and `cache/directory.rs` auto-creates a `UserAccount` with `UserRoles::User` when no principal matches. Lookup goes through `rcpt_id_from_parts`, which matches **aliases** as well as primary addresses, and the bearer path applies no alias-login permission check.

Nothing on this path consults `email_verified` — the address is whatever the IdP reports. So a claim-less token could provision an account outside our signup flow, or resolve to an existing principal that happens to own the address.

## What changed

- `crates/directory/src/backend/oidc/lookup.rs` — the configured claim is now the only accepted source of identity. Its absence returns `OidcError::Provider`, naming the claim.
- `tests/src/directory/oidc.rs` — a `claimUsername` the IdP does not issue must fail, even when the token carries `email`.

`Provider` rather than `AuthorizationFailed` is deliberate: `authenticate` maps `AuthorizationFailed` to `AuthEvent::Failed`, whose level resolves to `DEBUG` and is filtered out of production logging. Every other variant maps to `AuthEvent::Error`. A missing contracted claim is a misconfiguration worth seeing, and it renders as `Provider error: Claim '<name>' is missing …`, matching the existing `Network error: …` lines.

**The JWT path is unaffected.** Its userinfo fetch is *driven by* `resolve_email` returning `Err` (`lookup.rs:80-86`), so removing the fallback means userinfo is consulted more often, not less.

The HTTP response is unchanged — `crates/http/src/api/mod.rs` collapses `Failed`/`Error`/`TokenExpired` into one `RequestError::unauthorized()`. The gain is on the log side, plus the behaviour change itself.

## Testing

Verified locally on Rust 1.96.1. (Local stable is 1.92, and the `tests` crate pulls `libsqlite3-sys` 0.38.1 whose build script needs `cfg_select!` — stable in 1.95. Same constraint #30 pinned the Docker builder to 1.96 for.)

- `cargo check -p directory` — clean.
- `cargo check -p tests --tests` — clean, exit 0.
- `rustfmt --edition 2024 --check` — clean on both files.
- `STORE=Sqlite cargo test -p tests directory_tests` — **ok. 1 passed; 0 failed**, running all five groups (LDAP, OIDC, SQL, synchronization, integration).
- **Mutation-checked.** Restoring `resolve_email` from `main` while keeping the new test makes the suite panic at `tests/src/directory/oidc.rs:128` — the new assertion. So it genuinely covers this change rather than passing vacuously.

No existing test depends on the removed block: `tests/src/directory/oidc.rs` uses `claim_username: "preferred_username"` and `"email"`, and neither reaches the `claim_email != "email"` gate.

Two gotchas if you re-run `directory_tests` locally, neither related to this change:

- Keycloak's cold start took **156s** here against a `READY_TIMEOUT` of 180s, and the first attempt still timed out in `wait_for_http`. The container is `ReuseDirective::Always` under a fixed name, so a second run picks it up warm and passes.
- `STORE` must be set (e.g. `STORE=Sqlite`) or `synchronization::test()` panics with `Missing or invalid store type` before the suite finishes.

## Upstream note

`resolve_email` is unmodified upstream code (`72bc8c05`, and the userinfo fallback in `c0c889b7`), so this adds a small permanent conflict surface on each upstream sync — a 6-line block in one function.

## Rollout

Directory objects are startup-assembled: `Directories::build` reads `claimUsername` once, and `ObjectType::Directory` falls into the catch-all rebuild in `crates/common/src/cache/reload.rs`. The rolling restart from a Stalwart image bump covers this; a config-only change would need an explicit `ReloadSettings`.

Once merged, kagi-email needs `stalwartRev` and `hash` bumped in `flake.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
