### PR TITLE
fix: resolve sub-addresses in rcpt_id_from_email

### DIFF
--- a/crates/common/src/cache/principals.rs
+++ b/crates/common/src/cache/principals.rs
@@ -302,7 +302,38 @@ impl Server {
     pub async fn rcpt_id_from_email(&self, address: &str) -> trc::Result<Option<EmailCache>> {
         if let Some((local_part, domain)) = address.split_once('@') {
             if let Some(domain) = self.domain(domain).await? {
-                self.rcpt_id_from_parts(local_part, domain.id).await
+                // Sub-addressing resolution, matching rcpt_resolve and
+                // account_id_from_email. Without it this reports someone+tag@ as
+                // unknown while delivery resolves it to someone@, and the two
+                // disagreeing is worse than either answer: is_local_address is
+                // built on this, so a routing expression asking whether an address
+                // is local gets "no" for an address the server then delivers
+                // locally.
+                let mut local_part = Cow::Borrowed(local_part);
+                if domain.flags & DOMAIN_FLAG_SUB_ADDRESSING != 0 {
+                    if let Some(sub_addressing) = &domain.sub_addressing_custom {
+                        // Custom sub-addressing resolution
+                        if let Some(result) = self
+                            .eval_if::<String, _>(
+                                sub_addressing,
+                                &AddressResolver(local_part.as_ref()),
+                                0,
+                            )
+                            .await
+                        {
+                            local_part = Cow::Owned(result);
+                        }
+                    } else if let Some((new_local_part, _)) = address.split_once('+') {
+                        // Split from `address` rather than `local_part`, as the
+                        // sibling resolvers do: splitting the value being assigned
+                        // to would hold a borrow across the assignment. A domain
+                        // cannot contain '+', so the two are equivalent.
+                        local_part = Cow::Borrowed(new_local_part);
+                    }
+                }
+
+                self.rcpt_id_from_parts(local_part.as_ref(), domain.id)
+                    .await
             } else {
                 Ok(None)
             }

--- a/tests/src/system/directory.rs
+++ b/tests/src/system/directory.rs
@@ -328,6 +328,14 @@ pub async fn test(test: &TestServer) {
             EmailCache::Account(account_id.document_id()),
         ),
         (
+            // The same address rcpt_resolve rewrites to jdoe@example.com below.
+            // The two have to agree: is_local_address is built on this lookup, so
+            // a routing expression asking whether an address is local must not be
+            // told "no" about one the server then delivers locally.
+            "jdoe+promotions@example.com",
+            EmailCache::Account(account_id.document_id()),
+        ),
+        (
             "johndoe@beispiel.de",
             EmailCache::Account(account_id.document_id()),
         ),
@@ -368,6 +376,15 @@ pub async fn test(test: &TestServer) {
     assert_eq!(
         test.server
             .rcpt_id_from_email("unknown@unknown.com")
+            .await
+            .unwrap(),
+        None
+    );
+    // Sub-addressing resolves the local part; it does not conjure one. An unknown
+    // mailbox stays unknown however it is tagged.
+    assert_eq!(
+        test.server
+            .rcpt_id_from_email("unknown+promotions@example.com")
             .await
             .unwrap(),
         None


### PR DESCRIPTION
## The bug

`rcpt_id_from_email` looks up the **raw** local part:

```rust
if let Some((local_part, domain)) = address.split_once('@') {
    if let Some(domain) = self.domain(domain).await? {
        self.rcpt_id_from_parts(local_part, domain.id).await
```

Its two sibling resolvers both apply the domain's sub-addressing rule before looking up — `rcpt_resolve` (`crates/common/src/network/mta.rs`) and `account_id_from_email` (same file, a few hundred lines below). This one doesn't.

Since delivery goes through `rcpt_resolve`, the server resolves `someone+tag@` to `someone@` and delivers it, while `rcpt_id_from_email` reports that no such address exists.

## Why it matters

`is_local_address` is built on this lookup — it is the whole body of the expression function:

```rust
F_IS_LOCAL_ADDRESS => {
    let address = params.next_as_string();
    self.rcpt_id_from_email(address.as_ref()).await...map(|v| v.is_some().into())
}
```

So a routing expression that splits a domain between two servers:

```
rcpt_domain == 'example.com' && !is_local_address(rcpt)  ->  'elsewhere'
```

sends **every sub-addressed recipient elsewhere**, even when the base account is local and this server would have delivered it. The failure is silent and selective: plain addresses route correctly, and only the ones a user has tagged go to the wrong server.

We hit this migrating a domain onto Stalwart with exactly that expression. `cameron@` delivered locally; `cameron+2026-09-03a@` was handed to the old server.

## The fix

Apply the same resolution the siblings do, custom rule included. A sub-address of a local part that doesn't exist still resolves to nothing.

The `'+'` split reads from `address` rather than `local_part`, matching `account_id_from_email` — splitting the value being assigned to would hold a borrow across the assignment. A domain cannot contain `'+'`, so the two are equivalent.

## Tests

`tests/src/system/directory.rs` already asserts `rcpt_resolve("jdoe+promotions@example.com")` → `Rewrite("jdoe@example.com")`. Nothing asserted the same address through `rcpt_id_from_email` — which is why this went unnoticed. Now it does, alongside a case proving an unknown local part stays unknown however it is tagged.

`cargo check -p common` is clean (only pre-existing warnings). I could not run the test crate locally: `libsqlite3-sys` fails to build on my toolchain, the same issue as #30 ("build the image on Rust 1.96 — libsqlite3-sys needs cfg_select"), which is unrelated to this change. Both touched files are `rustfmt` clean.
